### PR TITLE
Cammovementfix

### DIFF
--- a/CityPCG-unity/Assets/App/CameraMovement.cs
+++ b/CityPCG-unity/Assets/App/CameraMovement.cs
@@ -17,6 +17,7 @@ public class CameraMovement : MonoBehaviour {
     private float prevMouseX = 0f;
     private float prevMouseY = 0f;
     private bool cursorLocked = false;
+    private float cappedDeltaTime = 0f;
 
     private void Start() {
         this.xRotation = transform.localEulerAngles.x;
@@ -25,25 +26,26 @@ public class CameraMovement : MonoBehaviour {
 
     private void Update() {
 
+        cappedDeltaTime = Mathf.Min(Time.deltaTime, 0.1f);
+
         if (Input.GetKey("w")) {
-            transform.position += transform.forward * moveSpeed * Mathf.Min(Time.deltaTime,0.5f);
+            transform.position += transform.forward * moveSpeed * cappedDeltaTime;
         }
         if (Input.GetKey("a")) {
-            transform.position -= transform.right * moveSpeed * Mathf.Min(Time.deltaTime,0.5f);
+            transform.position -= transform.right * moveSpeed * cappedDeltaTime;
         }
         if (Input.GetKey("s")) {
-            transform.position -= transform.forward * moveSpeed * Mathf.Min(Time.deltaTime,0.5f);
+            transform.position -= transform.forward * moveSpeed * cappedDeltaTime;
         }
         if (Input.GetKey("d")) {
-            transform.position += transform.right * moveSpeed * Mathf.Min(Time.deltaTime,0.5f);
+            transform.position += transform.right * moveSpeed * cappedDeltaTime;
         }
         if (Input.GetKey("q")) {
-            transform.position -= transform.up * moveSpeed * Mathf.Min(Time.deltaTime,0.5f);
+            transform.position -= transform.up * moveSpeed * cappedDeltaTime;
         }
         if (Input.GetKey("e") || Input.GetKey(KeyCode.Space)) {
-            transform.position += transform.up * moveSpeed * Mathf.Min(Time.deltaTime,0.5f);
+            transform.position += transform.up * moveSpeed * cappedDeltaTime;
         }
-
 
         // Lock cursor for 3D camera movement
         if (Input.GetMouseButton(1)) {


### PR DESCRIPTION
By request from Theodor. Made a maximum cap to Time.deltaTime for really laggy clients, as it would give unreasonably high movementspeed for really low framerates.

(also re-added space to be upward movement)